### PR TITLE
Fix styling in IE11

### DIFF
--- a/src/MainButton.js
+++ b/src/MainButton.js
@@ -22,7 +22,8 @@ const Wrapper = styled('a')(({ background, size }) => ({
 
 const IconWrapper = styled('div')(({ isOpen }) => ({
   display: 'flex',
-  position: 'absolute',
+  position: 'unset',
+  textDecoration: 'none',
   WebkitTransition: '-webkit-transform 300ms',
   transition: 'transform 300ms',
   WebkitTransform: `rotate(${isOpen ? 180 : 0}deg)`,

--- a/src/MainButton.js
+++ b/src/MainButton.js
@@ -22,7 +22,6 @@ const Wrapper = styled('a')(({ background, size }) => ({
 
 const IconWrapper = styled('div')(({ isOpen }) => ({
   display: 'flex',
-  position: 'unset',
   textDecoration: 'none',
   WebkitTransition: '-webkit-transform 300ms',
   transition: 'transform 300ms',


### PR DESCRIPTION
This doesn't work in IE11 it messed up the icon in the main button updating the position to unset and adding text-decoration to none fix it. Tested in IE11, Chrome, and Edge Chromium.